### PR TITLE
Add an nginx frontend server

### DIFF
--- a/protocols/shadowsocks-v2ray-tls/.env
+++ b/protocols/shadowsocks-v2ray-tls/.env
@@ -1,10 +1,7 @@
-
-CERT_DIR=/cert
-SS_CONTAINER=ss-server
-SERVER_PORT=4443
 METHOD=aes-256-gcm
 PASSWORD=MahsaAmini
 
+NGINX_CONTAINER=ss-nginx-frontend
 
 # Replace your_domain with the domain you bought, without http, or www in front of it, e.g.: google.com
 DOMAIN=your_domain

--- a/protocols/shadowsocks-v2ray-tls/build/start.sh
+++ b/protocols/shadowsocks-v2ray-tls/build/start.sh
@@ -2,6 +2,7 @@
 
 set -x
 
+CERT_DIR=/cert
 
 if [ "$1" == "daemon" ]; then
 

--- a/protocols/shadowsocks-v2ray-tls/docker-compose.yml
+++ b/protocols/shadowsocks-v2ray-tls/docker-compose.yml
@@ -8,22 +8,36 @@ services:
         ports:
             - "80:80/tcp"
         volumes:
-            - ./cert:${CERT_DIR}
+            - ./cert:/cert
             - /var/run/docker.sock:/var/run/docker.sock
         restart: always
         env_file: .env
         environment:
-            - "RELOADCMD=docker restart ${SS_CONTAINER}"
+            - "RELOADCMD=docker restart ${NGINX_CONTAINER}"
 
     ss-server:
-        container_name: ${SS_CONTAINER}
         image: acrisliu/shadowsocks-libev
         command:
             - "/start-server.sh"
         volumes:
             - ./scripts/start-server.sh:/start-server.sh:ro
-            - ./cert:${CERT_DIR}:ro
         restart: on-failure
         env_file: .env
+
+    nginx:
+        container_name: ${NGINX_CONTAINER}
+        image: nginx:1.23.1
+        volumes:
+          - ./nginx/templates:/etc/nginx/templates:ro
+          - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+          - ./cert:/etc/nginx/cert:ro
+          - ./scripts/wait-for-cert.sh:/wait-for-cert.sh
+        restart: on-failure
         ports:
-            - "443:4443/tcp"
+          - "443:443/tcp"
+        env_file: .env
+        ulimits:
+          nofile:
+            soft: 65535
+            hard: 65535
+        entrypoint: ["/wait-for-cert.sh", "/docker-entrypoint.sh", "nginx"]

--- a/protocols/shadowsocks-v2ray-tls/nginx/nginx.conf
+++ b/protocols/shadowsocks-v2ray-tls/nginx/nginx.conf
@@ -1,0 +1,33 @@
+daemon off;
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+worker_rlimit_nofile 65535;
+
+
+events {
+    worker_connections  10240;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/protocols/shadowsocks-v2ray-tls/nginx/templates/default.conf.template
+++ b/protocols/shadowsocks-v2ray-tls/nginx/templates/default.conf.template
@@ -1,0 +1,18 @@
+server {
+	#access_log /dev/stdout;
+	listen 443 ssl http2;
+	server_name ${DOMAIN};
+	ssl_certificate "/etc/nginx/cert/${DOMAIN}.cer";
+	ssl_certificate_key "/etc/nginx/cert/${DOMAIN}.key";
+	ssl_session_cache shared:SSL:1m;
+	ssl_session_timeout  10m;
+	location / {
+		proxy_redirect off;
+		proxy_http_version 1.1;
+		proxy_pass http://ss-server:8080;
+		proxy_set_header Host $http_host;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection "upgrade";
+	}
+}
+

--- a/protocols/shadowsocks-v2ray-tls/scripts/start-server.sh
+++ b/protocols/shadowsocks-v2ray-tls/scripts/start-server.sh
@@ -2,16 +2,9 @@
 
 set -xe
 
-CERT_PATH="${CERT_DIR}/${DOMAIN}.cer"
-KEY_PATH="${CERT_DIR}/${DOMAIN}.key"
 URL_PATH="${URL_PATH:-/${V2RAY_PATH}}"
 
-if [ ! -f "${CERT_PATH}" ] || [ ! -f "${KEY_PATH}" ]; then
-    echo "No cert or key file exist"
-    exit 0
-fi
-
-ARGS="--plugin v2ray-plugin --plugin-opts server;tls;fast-open;host=$DOMAIN;path=${URL_PATH};cert=$CERT_PATH;key=$KEY_PATH -u"
+ARGS="--plugin v2ray-plugin --plugin-opts server;fast-open;path=${URL_PATH} -u"
 
 android_url () {
     encoded_M_P=$(echo -n "$METHOD:$PASSWORD" | base64);
@@ -37,7 +30,7 @@ echo
 
 exec ss-server \
     -s 0.0.0.0 \
-    -p $SERVER_PORT \
+    -p 8080 \
     -k $PASSWORD \
     -m $METHOD \
     -t $TIMEOUT \

--- a/protocols/shadowsocks-v2ray-tls/scripts/wait-for-cert.sh
+++ b/protocols/shadowsocks-v2ray-tls/scripts/wait-for-cert.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# this script is expected to be used as an entrypoint for the nginx
+# container
+
+CERT_FILE=/etc/nginx/cert/${DOMAIN}.cer
+
+while [ ! -f $CERT_FILE ]; do
+    echo "Waiting for certificate $CERT_FILE before starting nginx..."
+    sleep 10
+done
+
+exec "$@"
+


### PR DESCRIPTION
I've found that allowing shadowsocks/v2ray handle client connections directly is problematic on occasion. For example, some (misbehaving or rogue) clients sometimes keep thousands of connections open to the server. This degrades v2ray performance a lot, effectively killing the server.

This setup, adds an nginx server responsible for handling client connections. This nginx server terminates TLS, so v2ray is now setup to use http.

A number of other small changes are also made:
 - Variables for setting internal details were removed from .env (CERT_DIR and SERVER_PORT). The user has no need to change these.
 - A script was added to wait for the certificate being issued before nginx starts.

I have been using this setup for a day or so and it seems very stable. Another member of the discord channel also gave it a try.