### PR TITLE
Add multi proxy with single line command.

### DIFF
--- a/protocols/one-click-multi-proxy/readme.md
+++ b/protocols/one-click-multi-proxy/readme.md
@@ -1,0 +1,19 @@
+This website provides a simple multi proxy method.
+- Telegram Proxy (faketls with fallback)
+- Shadowsocks+obfs (faketls with fallback)
+- Shadowsocks+v2ray (cdn support)
+- vmess (cdn support)
+- DNS over HTTPS (cdn support)
+- Redirector (cdn support)
+- Automatic use proxy for non-Iranian sites
+- Active probing resistant
+
+What you need is just a VPS with an ip and a subdomain (you can use free subdomains as described in the website)
+
+Just type your subdomain and secret and run the command in the VPS. 
+
+https://hiddify.github.io/setup-proxy-one-click.html
+
+It doesn't need any docker so you can run it in cheap VPS : [lists](https://github.com/hiddify/awesome-iran-freedom/blob/main/vps-providers.md)
+
+To add support for CDN, please follow the instuction in advanced setup in that page.


### PR DESCRIPTION
Add multi proxy with single line command.
Support:
- Telegram Proxy (faketls with fallback)
- Shadowsocks+obfs (faketls with fallback)
- Shadowsocks+v2ray (cdn support)
- vmess (cdn support)
- DNS over HTTPS (cdn support)
- Redirector (cdn support)
- Automatic use proxy for non-Iranian sites
- Active probing resistant
- Web interface for guiding users to setup proxy in their client